### PR TITLE
Update docker-compose to load datasource from the repository and add development file

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If Redis is running as Docker container on MacOS, please update host to `host.do
 
 ### Run using `docker-compose` for development
 
-Datasource have to be build following [BUILD](https://github.com/RedisTimeSeries/grafana-redis-datasource/blob/master/BUILD.md) instructions before starting using `docker-compose-dev.yml` file.
+Datasource have to be built following [BUILD](https://github.com/RedisTimeSeries/grafana-redis-datasource/blob/master/BUILD.md) instructions before starting using `docker-compose-dev.yml` file.
 
 ```bash
 docker-compose -f docker-compose-dev.yml up

--- a/README.md
+++ b/README.md
@@ -66,9 +66,7 @@ docker run -d -p 3000:3000 --name=grafana -e "GF_INSTALL_PLUGINS=redis-datasourc
 
 ### Run using `docker-compose`
 
-Project provides `docker-compose.yml` to start Redis with RedisTimeSeries module and Grafana 7.0.
-
-**Start Redis and Grafana**
+Project provides `docker-compose.yml` to start Redis with RedisTimeSeries module and Grafana.
 
 ```bash
 docker-compose up
@@ -104,6 +102,14 @@ If Redis is running as Docker container on MacOS, please update host to `host.do
 
 ```
     url: redis://host.docker.internal:6379
+```
+
+### Run using `docker-compose` for development
+
+Datasource have to be build following [BUILD](https://github.com/RedisTimeSeries/grafana-redis-datasource/blob/master/BUILD.md) instructions before starting using `docker-compose-dev.yml` file.
+
+```bash
+docker-compose -f docker-compose-dev.yml up
 ```
 
 ## Supported Commands

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,31 @@
+version: '3.4'
+
+services:
+  redis:
+    container_name: redistimeseries
+    image: redislabs/redistimeseries:latest
+    ports:
+      - '6379:6379'
+    # Uncomment and edit the local path in the following line to have
+    # RedisTimeSeries' data persisted to the host's filesystem.
+    # volumes:
+    #   - ./dump.rdb:/data/dump.rdb
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:latest
+    ports:
+      - '3000:3000'
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+      - GF_ENABLE_GZIP=true
+      - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=redis-datasource
+      # Uncomment to run in debug mode
+      # - GF_LOG_LEVEL=debug
+    volumes:
+      - ./dist:/var/lib/grafana/plugins/redis-datasource
+      - ./provisioning/datasources:/etc/grafana/provisioning/datasources
+      # Uncomment to preserve Grafana configuration
+      # - ./data:/var/lib/grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,8 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_BASIC_ENABLED=false
       - GF_ENABLE_GZIP=true
-      - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=redis-datasource
-      # Uncomment to run in debug mode
-      # - GF_LOG_LEVEL=debug
+      - GF_INSTALL_PLUGINS=redis-datasource
     volumes:
-      - ./dist:/var/lib/grafana/plugins/redis-datasource
       - ./provisioning/datasources:/etc/grafana/provisioning/datasources
       # Uncomment to preserve Grafana configuration
       # - ./data:/var/lib/grafana

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "grafana-toolkit plugin:test",
     "dev": "grafana-toolkit plugin:dev",
     "start": "docker-compose up",
+    "start:dev": "docker-compose -f docker-compose-dev.yml up",
     "watch": "grafana-toolkit plugin:dev --watch"
   },
   "author": "Redis Labs",


### PR DESCRIPTION
1) Update docker-compose to use Redis Datasource from the repository.
2) Add `docker-compose-dev` to start for development with built datasource.