### PR TITLE
Fix backend lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![RedisTimeSeries](https://img.shields.io/badge/RedisTimeSeries-inspired-yellowgreen)](https://oss.redislabs.com/redistimeseries/)
 [![Redis Enterprise](https://img.shields.io/badge/Redis%20Enterprise-supported-orange)](https://redislabs.com/redis-enterprise/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/RedisTimeSeries/grafana-redis-datasource)](https://goreportcard.com/report/github.com/RedisTimeSeries/grafana-redis-datasource)
+[![CircleCI](https://circleci.com/gh/RedisTimeSeries/grafana-redis-datasource.svg?style=svg)](https://circleci.com/gh/RedisTimeSeries/grafana-redis-datasource)
 
 ## Summary
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Grafana Redis Datasource",
   "scripts": {
     "build": "grafana-toolkit plugin:build",
-    "build:backend": "mage -v",
-    "test": "grafana-toolkit plugin:test",
+    "build:backend": "golangci-lint run && mage -v",
     "dev": "grafana-toolkit plugin:dev",
     "start": "docker-compose up",
     "start:dev": "docker-compose -f docker-compose-dev.yml up",
+    "test": "grafana-toolkit plugin:test",
     "watch": "grafana-toolkit plugin:dev --watch"
   },
   "author": "Redis Labs",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Grafana Redis Datasource",
   "scripts": {
     "build": "grafana-toolkit plugin:build",
-    "build:backend": "golangci-lint run && mage -v",
+    "build:backend": "mage -v lint && mage -v",
     "dev": "grafana-toolkit plugin:dev",
     "start": "docker-compose up",
     "start:dev": "docker-compose -f docker-compose-dev.yml up",

--- a/pkg/commands.go
+++ b/pkg/commands.go
@@ -134,17 +134,14 @@ func (ds *redisDatasource) queryCustomCommand(qm queryModel, client *radix.Pool)
 	/**
 	 * Check results and add frames
 	 */
-	switch result.(type) {
+	switch result := result.(type) {
 	case int64:
-		// Format number
-		value := result.(int64)
-
 		// Add Frame
 		response.Frames = append(response.Frames,
 			data.NewFrame(qm.Key,
-				data.NewField("Value", nil, []int64{value})))
+				data.NewField("Value", nil, []int64{result})))
 	case []byte:
-		value := string(result.([]byte))
+		value := string(result)
 
 		// Split lines
 		values := strings.Split(strings.Replace(value, "\r\n", "\n", -1), "\n")
@@ -160,28 +157,26 @@ func (ds *redisDatasource) queryCustomCommand(qm queryModel, client *radix.Pool)
 			data.NewFrame(qm.Key,
 				data.NewField("Value", nil, values)))
 	case string:
-		value := result.(string)
-
 		// Add the frames to the response
-		response.Frames = append(response.Frames, ds.createFrameValue(qm.Key, value))
+		response.Frames = append(response.Frames, ds.createFrameValue(qm.Key, result))
 	case []interface{}:
 		var values []string
 
 		// Parse array values
-		for _, value := range result.([]interface{}) {
-			switch value.(type) {
+		for _, value := range result {
+			switch value := value.(type) {
 			case []byte:
-				values = append(values, string(value.([]byte)))
+				values = append(values, string(value))
 			case []interface{}:
 				/**
 				 * Internal array
 				 */
-				for _, element := range value.([]interface{}) {
-					switch element.(type) {
+				for _, element := range value {
+					switch element := element.(type) {
 					case []byte:
-						values = append(values, string(element.([]byte)))
+						values = append(values, string(element))
 					case string:
-						values = append(values, element.(string))
+						values = append(values, element)
 					default:
 						response.Error = fmt.Errorf("Unsupported array return type")
 						return response
@@ -308,9 +303,9 @@ func (ds *redisDatasource) queryTsMRange(from int64, to int64, qm queryModel, cl
 	}
 
 	// Check results
-	switch result.(type) {
+	switch result := result.(type) {
 	case string:
-		response.Error = fmt.Errorf(result.(string))
+		response.Error = fmt.Errorf(result)
 		return response
 	default:
 	}
@@ -774,13 +769,13 @@ func (ds *redisDatasource) querySlowlogGet(qm queryModel, client *radix.Pool) ba
 			}
 
 			// Combine args into single command
-			switch arg.(type) {
+			switch arg := arg.(type) {
 			case int64:
-				command += strconv.FormatInt(arg.(int64), 10)
+				command += strconv.FormatInt(arg, 10)
 			case []byte:
-				command += string(arg.([]byte))
+				command += string(arg)
 			case string:
-				command += arg.(string)
+				command += arg
 			default:
 				log.DefaultLogger.Debug("Slowlog", "default", arg)
 			}

--- a/pkg/grafana-redis-datasource.go
+++ b/pkg/grafana-redis-datasource.go
@@ -66,8 +66,8 @@ func (ds *redisDatasource) QueryData(ctx context.Context, req *backend.QueryData
  * @see https://redis.io/commands/ping
  */
 func (ds *redisDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	var status = backend.HealthStatusUnknown
-	var message = "Data source health is yet to become known"
+	var status backend.HealthStatus
+	message := "Data source health is yet to become known"
 
 	// Get Instance
 	client, err := ds.getInstance(req.PluginContext)
@@ -81,6 +81,7 @@ func (ds *redisDatasource) CheckHealth(ctx context.Context, req *backend.CheckHe
 		// Check errors
 		if err != nil {
 			status = backend.HealthStatusError
+			message = "PING command failed"
 		} else {
 			status = backend.HealthStatusOk
 			message = "Data source working as expected"


### PR DESCRIPTION
```Running target: Lint
exec: golangci-lint run ./...
pkg/grafana-redis-datasource.go:69:6: ineffectual assignment to `status` (ineffassign)
	var status = backend.HealthStatusUnknown
	    ^
pkg/commands.go:137:9: S1034: assigning the result of this type assertion to a variable (switch result := result.(type)) could eliminate the following type assertions:
	pkg/commands.go:140:12
	pkg/commands.go:147:19
	pkg/commands.go:163:12 (gosimple)
	switch result.(type) {
	       ^
pkg/commands.go:172:11: S1034: assigning the result of this type assertion to a variable (switch value := value.(type)) could eliminate the following type assertions:
	pkg/commands.go:174:36 (gosimple)
			switch value.(type) {
			       ^
pkg/commands.go:180:13: S1034: assigning the result of this type assertion to a variable (switch element := element.(type)) could eliminate the following type assertions:
	pkg/commands.go:182:38
	pkg/commands.go:184:31 (gosimple)
					switch element.(type) {
					       ^
pkg/commands.go:311:9: S1034: assigning the result of this type assertion to a variable (switch result := result.(type)) could eliminate the following type assertions:
	pkg/commands.go:313:31 (gosimple)
	switch result.(type) {
	       ^
pkg/commands.go:777:11: S1034: assigning the result of this type assertion to a variable (switch arg := arg.(type)) could eliminate the following type assertions:
	pkg/commands.go:779:34
	pkg/commands.go:781:23
	pkg/commands.go:783:16 (gosimple)
			switch arg.(type) {
			       ^
Error: running "golangci-lint run ./..." failed with exit code 1

Exited with code exit status 1
CircleCI received exit code 1
```