### PR TITLE
Use bitbucket.org/creachadair/shell to parse Time-Series filter and custom query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/redistimeseries/grafana-redis-datasource
 go 1.14
 
 require (
+	bitbucket.org/creachadair/shell v0.0.6
 	github.com/grafana/grafana-plugin-sdk-go v0.75.0
 	github.com/magefile/mage v1.10.0 // indirect
 	github.com/mediocregopher/radix/v3 v3.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bitbucket.org/creachadair/shell v0.0.6 h1:reJflDbKqnlnqb4Oo2pQ1/BqmY/eCWcNGHrIUO8qIzc=
+bitbucket.org/creachadair/shell v0.0.6/go.mod h1:8Qqi/cYk7vPnsOePHroKXDJYmb5x7ENhtiFtfZq8K+M=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/pkg/redis-time-series.go
+++ b/pkg/redis-time-series.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
+	"bitbucket.org/creachadair/shell"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -73,7 +73,13 @@ func (ds *redisDatasource) queryTsMRange(from int64, to int64, qm queryModel, cl
 	var err error
 
 	// Split Filter to array
-	filter := strings.Fields(qm.Filter)
+	filter, ok := shell.Split(qm.Filter)
+
+	// Check if filter is valid
+	if !ok {
+		response.Error = fmt.Errorf("Filter is not valid")
+		return response
+	}
 
 	// Execute command
 	if qm.Aggregation != "" {
@@ -283,7 +289,13 @@ func (ds *redisDatasource) queryTsQueryIndex(qm queryModel, client *radix.Pool) 
 	response := backend.DataResponse{}
 
 	// Split Filter to array
-	filter := strings.Fields(qm.Filter)
+	filter, ok := shell.Split(qm.Filter)
+
+	// Check if filter is valid
+	if !ok {
+		response.Error = fmt.Errorf("Filter is not valid")
+		return response
+	}
 
 	// Execute command
 	var values []string


### PR DESCRIPTION
The Split function divides a string into whitespace-separated fields, respecting single and double quotation marks as defined by the Shell Command Language section of IEEE Std 1003.1 2013.