### PR TITLE
MRANGE: add fill zero option

### DIFF
--- a/src/redis/command.ts
+++ b/src/redis/command.ts
@@ -106,5 +106,5 @@ export const CommandParameters = {
   legendLabel: ['ts.mrange'],
   section: ['info'],
   valueLabel: ['ts.mrange'],
-  fill: ['ts.range'],
+  fill: ['ts.range', 'ts.mrange'],
 };


### PR DESCRIPTION
@mikhailredis Thank you for adding the "Fill Missing" field to `TS.RANGE` queries.

This commit applies the same logic to `TS.MRANGE` queries where I've found it to be useful as well. Screenshots of before/after below:

**Before**
![Screenshot from 2020-08-23 10-21-33](https://user-images.githubusercontent.com/2764032/90984636-0b0d5900-e52b-11ea-8554-2c0a5cedbe64.png)

**After**
![Screenshot from 2020-08-23 10-21-46](https://user-images.githubusercontent.com/2764032/90984639-119bd080-e52b-11ea-9abd-1f00d2989bba.png)

I haven't written much go before -- please let me know if there are style/syntax things missing here and I'm happy to correct them. Also happy to hand off the branch to get it fixed up and merged in.

Thanks again!
